### PR TITLE
Fix typo

### DIFF
--- a/pages/getting-started/rpc-endpoints.mdx
+++ b/pages/getting-started/rpc-endpoints.mdx
@@ -41,7 +41,7 @@ network information:
       </td>
     </tr>
     <tr>
-      <td>Currenty Symbol</td>
+      <td>Currency Symbol</td>
       <td>
         <CopiableText value="Eth" text="Eth" />
       </td>


### PR DESCRIPTION
It would be better to offer a one-click button to add the network, similar to (and also available through) chainlist.org.