### PR TITLE
Adds Chainstack Sepolia faucet to testnet.mdx

### DIFF
--- a/pages/tools/testnet.mdx
+++ b/pages/tools/testnet.mdx
@@ -8,4 +8,4 @@ The following are links to our testnet tools:
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Block Explorer | [explorer.sepolia.publicgoods.network](https://explorer.sepolia.publicgoods.network/)                                                                                                            |
 | Bridge         | [bridge.sepolia.publicgoods.network](https://bridge.sepolia.publicgoods.network/)                                                                                                                                   |
-| Faucet         | [sepoliafaucet.com](https://sepoliafaucet.com), [infura.io/faucet/sepolia](https://infura.io/faucet/sepolia), or [faucetlink.to/sepolia](https://faucetlink.to/sepolia) |
+| Faucet         | [sepoliafaucet.com](https://sepoliafaucet.com), [infura.io/faucet/sepolia](https://infura.io/faucet/sepolia), [faucetlink.to/sepolia](https://faucetlink.to/sepolia), or [faucet.chainstack.com/sepolia-faucet](https://faucet.chainstack.com/sepolia-faucet) |


### PR DESCRIPTION
Simple PR that includes the Chainstack Sepolia faucet among the options present in testnet.mdx