### PR TITLE
Added a new section to the Bridging page, as well as a new FAQ.

### DIFF
--- a/pages/faq.mdx
+++ b/pages/faq.mdx
@@ -1,5 +1,26 @@
 # FAQs
 
+## High-traffic support requests
+
+### Why can't I bridge tokens from PGN back to Ethereum, quickly?
+
+PGN is an OP Stack L2, which has a specific process for bridging tokens from the L2 (PGN) back to the L1 (Ethereum). 
+
+When bridging, your transaction must go through a seven day challenge period. 
+
+This challenge period is important, as it is designed to protect users from fraud.  During this period, a user can submit a fault proof to challenge a transaction before it is relayed from the L2 to the L1. 
+
+To successfully bridge from PGN to Ethereum, you must follow these instructions:
+1. Submit the transaction using the bridge.
+2. Navigate to the [Transactions](https://bridge.sepolia.publicgoods.network/transactions) page. You will eventually see your transaction show up with the status, "Waiting for state root".
+3. Within 30 minutes, your transaction status will change to "Ready to prove." Click the "Prove" button to initiate the challenge window.
+4. The transaction status will change to "In challenge period" and will display how much time is left in the period via the "Time left" column. 
+5. Once the challenge period is over, the transaction status will change to "Ready to relay". You will need to click the "Finalize" button to relay the transaction to PGN. 
+
+At this point, the transaction should say "Relayed", which means that the tokens have successfully been bridged to Ethereum. 
+
+**If you don't perform all of these tasks, your transaction will not be bridged properly.**
+
 ## PGN Basics
 
 ### What is PGN?

--- a/pages/using-pgn/bridging-eth-to-pgn.mdx
+++ b/pages/using-pgn/bridging-eth-to-pgn.mdx
@@ -11,6 +11,8 @@ Please do not transfer large amounts of ETH to PGN. It is recommended to transfe
 Also, do not directly transfer WETH or any ERC-20 tokens to the bridge address.
 </Callout>
 
+
+
 ## Using the PGN Bridge
 
 ### Mainnet
@@ -36,9 +38,34 @@ Although the bridge will offer status updates when the transaction state changes
 You can review your bridge transactions by navigation to the [block explorer](https://explorer.publicgoods.network) and searching for your wallet address. Note that you might need to use your actual wallet address instead of an ENS or custom domain name. 
 
 
-### Testnet
+#### Bridging from PGN to Ethereum 
 
-The instructions for testnet are very similar. However, you will use the following PGN Sepolia bridge, and bridge from Sepolia to PGN Testnet instead. 
+When bridging tokens from PGN to Ethereum, your transaction must go through a seven day challenge period. 
+
+This challenge period is important, as it is designed to protect users from fraud.  During this period, a user can submit a fault proof to challenge a transaction before it is relayed from the L2 to the L1. 
+
+To successfully bridge from PGN to Ethereum, you must follow these instructions:
+1. Submit the transaction using the bridge.
+2. Navigate to the [Transactions](https://bridge.sepolia.publicgoods.network/transactions) page. You will eventually see your transaction show up with the status, "Waiting for state root".
+3. Within 30 minutes, your transaction status will change to "Ready to prove." Click the "Prove" button to initiate the challenge window.
+4. The transaction status will change to "In challenge period" and will display how much time is left in the period via the "Time left" column. 
+5. Once the challenge period is over, the transaction status will change to "Ready to relay". You will need to click the "Finalize" button to relay the transaction to PGN. 
+
+At this point, the transaction should say "Relayed", which means that the tokens have successfully been bridged to Ethereum. 
+
+
+Some key details to understand around the timing of a challenge period:
+* The challenge period ends after seven days, regardless of whether or not a fault proof has been submitted.
+* If a fault proof is submitted after the challenge period has ended, the challenge will be dismissed. 
+* You can only challenge a transaction that you have personally submitted.
+* You cannot challenge a transaction that has already been withdrawn.
+
+You can learn more by reading the [Optimism documentation](https://community.optimism.io/docs/developers/bridge/messaging/#understanding-the-challenge-period) on the subject. 
+
+
+## Testnet
+
+The instructions for testnet are very similar to mainnet. However, you will use the following PGN Sepolia bridge, and bridge from Sepolia to PGN Testnet instead. 
 [bridge.sepolia.publicgoods.network](https://bridge.sepolia.publicgoods.network)
 
 If you need to request testnet Sepolia ETH, you can do so via the following faucets:


### PR DESCRIPTION
Added a couple of new sections. 

Along with this docs update, we should also update the helper text within both the Sepolia and the mainnet bridges, and update the link at the very bottom of the page (after being expanded) to point directly to the "[bridging](https://docs.publicgoods.network/using-pgn/bridging-eth-to-pgn#bridging-from-pgn-to-ethereum)" url in the docs. 