### PR TITLE
Added an FAQ about network/contract details, re: Safe / multisig

### DIFF
--- a/pages/building-with-pgn.mdx
+++ b/pages/building-with-pgn.mdx
@@ -3,7 +3,7 @@
 ## Key resources
 
 * [Network and Contract details](/network-and-contract-details)
-* [Deploying on PGN](/building-with-pgn/deploying-on-pgn)
+* [Deploying on PGN](/building-with-pgn/deploying-to-pgn)
 * [Ethereum vs PGN](/building-with-pgn/fees)
 * [Subgraphs](/building-with-pgn/subgraphs)
 * [Fees](/building-with-pgn/ethereum-vs-pgn)

--- a/pages/faq.mdx
+++ b/pages/faq.mdx
@@ -38,6 +38,13 @@ Instead, please join us on Telegram: [Join](https://t.me/+aR__6QhfEWs3ZTcx)
 
 **There is no Discord server - please don’t fall victim to scams asking you to join a server.**
 
+### Where can I find the network and contract information for PGN?
+
+We have listed all network and contract information in a dedicated documentation page:
+[docs.publicgoods.network/network-and-contract-details](https://docs.publicgoods.network/network-and-contract-details)
+
+For those of you that are interested in using [Safe](https://safe.global) contracts, we have a dedicated section within the previously noted page that lists all [Safe contract names and addresses](https://docs.publicgoods.network/network-and-contract-details#safe-contract-addresses). 
+
 
 ## PGN Basics
 
@@ -208,6 +215,7 @@ As of July 25th, 2023, we have had several partners either fully deploy or deplo
 * [Safe](https://safe.global/)
 * [The Graph](https://thegraph.com/)
 * [Goldsky](https://goldsky.com/)
+
 
 ## Deploying contracts
 


### PR DESCRIPTION
I specifically added this to call out Safe within the FAQs. 

After reviewing several pieces of content around sending and recovering funds from different networks using Safe, I don't think we need an FAQ on PGN about it. 

Resources I reviewed:
* https://www.loom.com/share/ca34aabcd62747fb9fb89bd463b4c741
* https://forum.safe.global/t/enable-same-safe-address-across-all-chains/3632
* https://forum.safe.global/t/how-can-a-safe-hold-asset-on-multiple-chains/2242
* https://help.safe.global/en/articles/40812-i-sent-assets-to-a-safe-address-on-the-wrong-network-any-chance-to-recover

I could see an argument for us including some information about needing to have a separate Safe for each network that you use since they are network-specific (at least I think this is still the case). 

I also tried to create a Safe wallet on the PGN network and wasn't able to using the safe.global UI. When do we expect this to become available?

Please let me know if I'm missing anything. 